### PR TITLE
Ensure all static files are included

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ recursive-include docs-italia-theme *.eot
 recursive-include docs-italia-theme *.html
 recursive-include docs-italia-theme *.js
 recursive-include docs-italia-theme *.svg
+recursive-include docs-italia-theme *.png
 recursive-include docs-italia-theme *.ttf
 recursive-include docs-italia-theme *.woff
 recursive-include docs-italia-theme *.woff2

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         'static/css/*.css',
         'static/icons/*.*',
         'static/js/*.js',
+        'static/*.png',
+        'static/*.svg',
         'static/font/*.*',
         'data/*.*',
     ]},


### PR DESCRIPTION
The end result is the same as the `static/icons/*.*` rule but it looks more generic and doesn't hurt.