### PR TITLE
Guard against figurenode without ids

### DIFF
--- a/docs_italia_theme/__init__.py
+++ b/docs_italia_theme/__init__.py
@@ -133,6 +133,8 @@ def generate_additonal_tocs(app, pagename, templatename, context, doctree):
         doctree_page = app.env.get_doctree(page)
 
         for figurenode in doctree_page.traverse(figure):
+            if not figurenode.attributes['ids']:
+                continue
             figure_id = figurenode.attributes['ids'][0]
             toc_fig_tables = app.env.toc_fignumbers[page].get('figure', {})
             figure_number = toc_fig_tables.get(figure_id)


### PR DESCRIPTION
Fixes:

```
File "/lg-patrimonio-pubblico/local/lib/python2.7/site-packages/docs_italia_theme/__init__.py", line 136, in generate_additonal_tocs
    figure_id = figurenode.attributes['ids'][0]
IndexError: list index out of range
```