### PR TITLE
Change style of the bullet points to disc.

### DIFF
--- a/sass/layout/_content.scss
+++ b/sass/layout/_content.scss
@@ -206,24 +206,12 @@
 
   ul.simple,
   ul.simple ul {
-    list-style-type: none;
+    list-style-type: disc;
 
     li {
       position: relative;
       margin-bottom: 0.5rem;
       font-size: 0.9rem;
-
-      &::after {
-        content: '';
-        width: 0;
-        height: 0;
-        border-top: 5px solid transparent;
-        border-bottom: 5px solid transparent;
-        border-left: 5px solid $grey-mid;
-        position: absolute;
-        left: -1rem;
-        top: 0.4rem;
-      }
 
       ul li {
         margin-top: 0.5rem;


### PR DESCRIPTION
Change style of the bullet points to disc to avoid confusing them
with expanding arrows.

Fix #187.