### PR TITLE
feat: remove Google Analytics and the cookie banner

### DIFF
--- a/docs_italia_theme/layouts/default.html
+++ b/docs_italia_theme/layouts/default.html
@@ -44,9 +44,6 @@
   {% include 'layouts/scripts.html' %}
   {% endblock %}
   {% include 'layouts/web-analytics.html' %}
-  {% if builder != 'readthedocssinglehtmllocalmedia' %}
-    {% include 'layouts/cookiebar.html' %}
-  {% endif %}
   {% if docsitalia_data %}
   {% include 'layouts/document_modals.html' %}
   {% endif %}

--- a/docs_italia_theme/layouts/web-analytics.html
+++ b/docs_italia_theme/layouts/web-analytics.html
@@ -1,56 +1,15 @@
 <script type="text/javascript">
-  <!-- Google analytics -->
-  (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r;
-    i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date();
-    a = s.createElement(o), m = s.getElementsByTagName(o)[0];
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m)
-  })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-
-  $(document).ready(function() {
-    var sendGaPageview = function() {
-      ga('create', '{{ global_analytics_code }}', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
-      {% if user_analytics_code %}
-      ga('create', '{{ user_analytics_code }}', 'auto', 'user');
-      ga('user.send', 'pageview');
-      {% endif %}
-    };
-    if ($.fn['cookiebar'].Constructor._getCookieEU()) {
-      sendGaPageview();
-    } else {
-      $(document).on('close.bs.cookiebar', sendGaPageview);
-    }
-  });
-  <!-- End Google analytics -->
   <!-- Matomo -->
-  /*
-  var _paq = _paq || [];
-  _paq.push(['setSiteId', '{{ site.piwik }}']);
-  (function () {
-    var u = '//italia.piwikpro.com/';
-    _paq.push(['setTrackerUrl', u + 'piwik.php']);
-    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-    g.type = 'text/javascript'; g.async = true; g.defer = true; g.src = u + 'piwik.js'; s.parentNode.insertBefore(g, s);
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://ingestion.webanalytics.italia.it/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
-
-  $(document).ready(function() {
-    var sendMatomoPageview = function() {
-      _paq.push(['setDocumentTitle', document.domain + '/' + document.title]);
-      _paq.push(['enableLinkTracking']);
-      _paq.push(['setDoNotTrack', 1]);
-      _paq.push(['trackPageView']);
-    };
-    if ($.fn['cookiebar'].Constructor._getCookieEU()) {
-      sendMatomoPageview();
-    } else {
-      $(document).on('close.bs.cookiebar', sendMatomoPageview);
-    }
-  });*/
   <!-- End Matomo -->
 </script>


### PR DESCRIPTION
Remove the support for project specific Google analytics codes and
replace it with Matomo.

We need to change Docs Italia's code in order to have feature parity
and supporting project specific Matomo siteIds, so for now the
id is empty for everyone until we have that feature.

Also remove the cookie banner because we are not serving tracking
cookies.